### PR TITLE
Bump action runtime to Node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ inputs:
     required: false
     default: 'coverage'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: 'percent'

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "undici": "^7.24.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "package:watch": "ncc build index.js --watch"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "jest": {
     "coverageReporters": [


### PR DESCRIPTION
Update the action runtime from `node20` to `node24` in `action.yml` and bump the package `engines` requirement to `>=24` to match the CI matrix (which already tests on Node 24).

Rebuilt the `dist/` bundle with `npm run package`; output is byte-identical since only the runtime declaration changed, so the "Verify dist/ matches source" CI step passes.